### PR TITLE
Structured results (semver-major)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,23 @@ Using the acorn tokenizer it will enumerate files that have been referenced from
 esm `import` or commonjs `require`.
 
 ```js
-const findRelationsInJs = require('@gustavnikolaj/find-relations-in-js');
+const findRelationsInJs = require("@gustavnikolaj/find-relations-in-js");
 
 findRelationsInJs(`
-import foo from './bar.js';
-require('./baz');
-`) => // ['./bar.js', './baz']
+  import foo from './bar.js';
+  require('./baz');
+`); /* => [
+  {
+    type: 'import',
+    value: './bar.js',
+    source: 'import foo from \'./bar.js\'',
+    offset: { start: 3, end: 29 }
+  },
+  {
+    type: 'require',
+    value: './baz',
+    source: 'require(\'./baz\')',
+    offset: { start: 33, end: 57 }
+  }
+] */
 ```

--- a/lib/find-relations-in-js.js
+++ b/lib/find-relations-in-js.js
@@ -2,6 +2,13 @@ const acorn = require("acorn");
 const acornJsx = require("acorn-jsx");
 const Parser = acorn.Parser.extend(acornJsx());
 
+function getSourceAndOffset(source, start, end) {
+  return {
+    source: source.substring(start, end),
+    offset: { start, end }
+  };
+}
+
 module.exports = function findRelationsInJs(source) {
   const relations = [];
   const tokens = Array.from(Parser.tokenizer(source));
@@ -20,11 +27,7 @@ module.exports = function findRelationsInJs(source) {
         relations.push({
           type: "import",
           value: tokens[i + 3].value,
-          source: source.substring(token.start, tokens[i + 3].end),
-          offset: {
-            start: token.start,
-            end: tokens[i + 3].end
-          }
+          ...getSourceAndOffset(source, token.start, tokens[i + 3].end)
         });
         i += 4;
         continue;
@@ -33,11 +36,7 @@ module.exports = function findRelationsInJs(source) {
         relations.push({
           type: "import",
           value: tokens[i + 1].value,
-          source: source.substring(token.start, tokens[i + 1].end),
-          offset: {
-            start: token.start,
-            end: tokens[i + 1].end
-          }
+          ...getSourceAndOffset(source, token.start, tokens[i + 1].end)
         });
         i += 2;
         continue;
@@ -61,11 +60,7 @@ module.exports = function findRelationsInJs(source) {
           relations.push({
             type: "import",
             value: tokens[j + 2].value,
-            source: source.substring(token.start, tokens[j + 2].end),
-            offset: {
-              start: token.start,
-              end: tokens[j + 2].end
-            }
+            ...getSourceAndOffset(source, token.start, tokens[j + 2].end)
           });
           i = j + 3;
           continue;
@@ -78,7 +73,7 @@ module.exports = function findRelationsInJs(source) {
         // import identifier, {identifiers} from <string>
         let j = i + 4;
 
-        for (let k = i + 4; k++; k < tokens.length) {
+        for (let k = i + 4; k < tokens.length; k++) {
           // consume non }-tokens
           if (tokens[k].type.label === "}") {
             j = k;
@@ -94,37 +89,34 @@ module.exports = function findRelationsInJs(source) {
           relations.push({
             type: "import",
             value: tokens[j + 2].value,
-            source: source.substring(token.start, tokens[j + 2].end),
-            offset: {
-              start: token.start,
-              end: tokens[j + 2].end
-            }
+            ...getSourceAndOffset(source, token.start, tokens[j + 2].end)
           });
           i = j + 3;
           continue;
         }
       }
 
-      console.log(tokens);
-
-      console.warn("unmatched import");
+      relations.push({
+        error: "Incomprehensible import",
+        type: "import",
+        ...getSourceAndOffset(source, token.start, token.end)
+      });
     }
 
     if (token.type.label === "name" && token.value === "require") {
       if (
+        tokens[i + 1] &&
         tokens[i + 1].type.label === "(" &&
+        tokens[i + 2] &&
         tokens[i + 2].type.label === "string" &&
+        tokens[i + 3] &&
         tokens[i + 3].type.label === ")"
       ) {
         // require(<string>)
         relations.push({
           type: "require",
           value: tokens[i + 2].value,
-          source: source.substring(token.start, tokens[i + 3].end),
-          offset: {
-            start: token.start,
-            end: tokens[i + 3].end
-          }
+          ...getSourceAndOffset(source, token.start, tokens[i + 3].end)
         });
         i += 4;
         continue;
@@ -132,8 +124,7 @@ module.exports = function findRelationsInJs(source) {
         if (tokens[i + 1].type.label === "(") {
           let j = null;
 
-          for (let k = i + 1; k++; k < tokens.length) {
-            // consume non }-tokens
+          for (let k = i + 1; k < tokens.length; k++) {
             if (tokens[k].type.label === ")") {
               j = k;
               break;
@@ -144,17 +135,18 @@ module.exports = function findRelationsInJs(source) {
             relations.push({
               error: "Non literal require.",
               type: "require",
-              source: source.substring(token.start, tokens[j].end),
-              offset: {
-                start: token.start,
-                end: tokens[j].end
-              }
+              ...getSourceAndOffset(source, token.start, tokens[j].end)
             });
           } else {
-            console.log("imcomplete require statement");
+            relations.push({
+              error: "Incomplete require statement",
+              type: "require",
+              ...getSourceAndOffset(source, token.start, tokens[i + 1].end)
+            });
           }
         } else {
-          console.warn("unmatched require", token);
+          // This is anything which is named require, but isn't called as a
+          // function, e.g. a random variable or argument named require.
         }
       }
     }

--- a/lib/find-relations-in-js.js
+++ b/lib/find-relations-in-js.js
@@ -17,12 +17,28 @@ module.exports = function findRelationsInJs(source) {
         tokens[i + 3].type.label === "string"
       ) {
         // import identifier from <string>
-        relations.push(tokens[i + 3].value);
+        relations.push({
+          type: "import",
+          value: tokens[i + 3].value,
+          source: source.substring(token.start, tokens[i + 3].end),
+          offset: {
+            start: token.start,
+            end: tokens[i + 3].end
+          }
+        });
         i += 4;
         continue;
       } else if (tokens[i + 1].type.label === "string") {
         // import <string>
-        relations.push(tokens[i + 1].value);
+        relations.push({
+          type: "import",
+          value: tokens[i + 1].value,
+          source: source.substring(token.start, tokens[i + 1].end),
+          offset: {
+            start: token.start,
+            end: tokens[i + 1].end
+          }
+        });
         i += 2;
         continue;
       } else if (tokens[i + 1].type.label === "{") {
@@ -42,7 +58,15 @@ module.exports = function findRelationsInJs(source) {
           tokens[j + 2].type.label === "string"
         ) {
           // } from <string>
-          relations.push(tokens[j + 2].value);
+          relations.push({
+            type: "import",
+            value: tokens[j + 2].value,
+            source: source.substring(token.start, tokens[j + 2].end),
+            offset: {
+              start: token.start,
+              end: tokens[j + 2].end
+            }
+          });
           i = j + 3;
           continue;
         }
@@ -67,7 +91,15 @@ module.exports = function findRelationsInJs(source) {
           tokens[j + 2].type.label === "string"
         ) {
           // } from <string>
-          relations.push(tokens[j + 2].value);
+          relations.push({
+            type: "import",
+            value: tokens[j + 2].value,
+            source: source.substring(token.start, tokens[j + 2].end),
+            offset: {
+              start: token.start,
+              end: tokens[j + 2].end
+            }
+          });
           i = j + 3;
           continue;
         }
@@ -85,11 +117,45 @@ module.exports = function findRelationsInJs(source) {
         tokens[i + 3].type.label === ")"
       ) {
         // require(<string>)
-        relations.push(tokens[i + 2].value);
+        relations.push({
+          type: "require",
+          value: tokens[i + 2].value,
+          source: source.substring(token.start, tokens[i + 3].end),
+          offset: {
+            start: token.start,
+            end: tokens[i + 3].end
+          }
+        });
         i += 4;
         continue;
       } else {
-        console.warn("unmatched require");
+        if (tokens[i + 1].type.label === "(") {
+          let j = null;
+
+          for (let k = i + 1; k++; k < tokens.length) {
+            // consume non }-tokens
+            if (tokens[k].type.label === ")") {
+              j = k;
+              break;
+            }
+          }
+
+          if (j) {
+            relations.push({
+              error: "Non literal require.",
+              type: "require",
+              source: source.substring(token.start, tokens[j].end),
+              offset: {
+                start: token.start,
+                end: tokens[j].end
+              }
+            });
+          } else {
+            console.log("imcomplete require statement");
+          }
+        } else {
+          console.warn("unmatched require", token);
+        }
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "^6.0.1",
     "eslint-config-pretty-standard": "^2.0.1",
     "eslint-plugin-import": "^2.18.0",
+    "imocha": "^0.7.0",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
     "prettier": "^1.18.2",

--- a/test/find-relations-in-js.spec.js
+++ b/test/find-relations-in-js.spec.js
@@ -247,4 +247,48 @@ describe("find-relations-in-js", () => {
       ]
     );
   });
+
+  it("should not crash on an unterminated require statement", () => {
+    expect(
+      findRelationsInJs(`
+        require('fdsf'
+      `),
+      "to equal",
+      [
+        {
+          error: "Incomplete require statement",
+          type: "require",
+          source: "require(",
+          offset: { start: 9, end: 17 }
+        }
+      ]
+    );
+  });
+
+  it("should ignore a variable named require", () => {
+    expect(
+      findRelationsInJs(`
+        var require = 'foo'
+      `),
+      "to equal",
+      []
+    );
+  });
+
+  it("should not crash on dynamic import", () => {
+    expect(
+      findRelationsInJs(`
+        import('fdsf');
+      `),
+      "to equal",
+      [
+        {
+          error: "Incomprehensible import",
+          type: "import",
+          source: "import",
+          offset: { start: 9, end: 15 }
+        }
+      ]
+    );
+  });
 });

--- a/test/find-relations-in-js.spec.js
+++ b/test/find-relations-in-js.spec.js
@@ -22,7 +22,14 @@ describe("find-relations-in-js", () => {
         import foo from './bar.js';
       `),
       "to equal",
-      ["./bar.js"]
+      [
+        {
+          type: "import",
+          value: "./bar.js",
+          source: "import foo from './bar.js'",
+          offset: { start: 9, end: 35 }
+        }
+      ]
     );
   });
 
@@ -32,7 +39,14 @@ describe("find-relations-in-js", () => {
         import './foo.js';
       `),
       "to equal",
-      ["./foo.js"]
+      [
+        {
+          type: "import",
+          value: "./foo.js",
+          source: "import './foo.js'",
+          offset: { start: 9, end: 26 }
+        }
+      ]
     );
   });
 
@@ -42,7 +56,14 @@ describe("find-relations-in-js", () => {
         const foo = require('./bar.js');
       `),
       "to equal",
-      ["./bar.js"]
+      [
+        {
+          type: "require",
+          value: "./bar.js",
+          source: "require('./bar.js')",
+          offset: { start: 21, end: 40 }
+        }
+      ]
     );
   });
 
@@ -55,7 +76,14 @@ describe("find-relations-in-js", () => {
         }
       `),
       "to equal",
-      ["react"]
+      [
+        {
+          type: "import",
+          value: "react",
+          source: "import React from 'react'",
+          offset: { start: 9, end: 34 }
+        }
+      ]
     );
   });
 
@@ -65,7 +93,14 @@ describe("find-relations-in-js", () => {
         import { Component } from 'react';
       `),
       "to equal",
-      ["react"]
+      [
+        {
+          type: "import",
+          value: "react",
+          source: "import { Component } from 'react'",
+          offset: { start: 9, end: 42 }
+        }
+      ]
     );
   });
 
@@ -75,7 +110,14 @@ describe("find-relations-in-js", () => {
         import { Component, Fragment } from 'react';
       `),
       "to equal",
-      ["react"]
+      [
+        {
+          type: "import",
+          value: "react",
+          source: "import { Component, Fragment } from 'react'",
+          offset: { start: 9, end: 52 }
+        }
+      ]
     );
   });
 
@@ -85,7 +127,14 @@ describe("find-relations-in-js", () => {
         import React, { Component } from 'react';
       `),
       "to equal",
-      ["react"]
+      [
+        {
+          type: "import",
+          value: "react",
+          source: "import React, { Component } from 'react'",
+          offset: { start: 9, end: 49 }
+        }
+      ]
     );
   });
 
@@ -100,7 +149,21 @@ describe("find-relations-in-js", () => {
         'prop-types';
       `),
       "to equal",
-      ["react", "prop-types"]
+      [
+        {
+          type: "import",
+          value: "react",
+          source: "import React, { Component }\n        from 'react'",
+          offset: { start: 9, end: 57 }
+        },
+        {
+          type: "import",
+          value: "prop-types",
+          source:
+            "import\n        PropTypes\n        from\n        'prop-types'",
+          offset: { start: 67, end: 125 }
+        }
+      ]
     );
   });
 
@@ -111,7 +174,14 @@ describe("find-relations-in-js", () => {
         const bar = require(foo);
       `),
       "to equal",
-      []
+      [
+        {
+          error: "Non literal require.",
+          type: "require",
+          source: "require(foo)",
+          offset: { start: 50, end: 62 }
+        }
+      ]
     );
   });
 
@@ -124,7 +194,57 @@ describe("find-relations-in-js", () => {
         import { omit } from 'lodash';
       `),
       "to equal",
-      ["react", "prop-types", "lodash", "lodash"]
+      [
+        {
+          type: "require",
+          value: "react",
+          source: "require('react')",
+          offset: { start: 23, end: 39 }
+        },
+        {
+          type: "require",
+          value: "prop-types",
+          source: `require("prop-types")`,
+          offset: { start: 67, end: 88 }
+        },
+        {
+          type: "import",
+          value: "lodash",
+          source: `import { pick } from "lodash"`,
+          offset: { start: 98, end: 127 }
+        },
+        {
+          type: "import",
+          value: "lodash",
+          source: "import { omit } from 'lodash'",
+          offset: { start: 137, end: 166 }
+        }
+      ]
+    );
+  });
+
+  it("should return a list of imported files", () => {
+    expect(
+      findRelationsInJs(`
+        import foo from './someFile'
+        import './another-file';
+        export default function () {};
+      `),
+      "to equal",
+      [
+        {
+          type: "import",
+          value: "./someFile",
+          source: "import foo from './someFile'",
+          offset: { start: 9, end: 37 }
+        },
+        {
+          type: "import",
+          value: "./another-file",
+          source: "import './another-file'",
+          offset: { start: 46, end: 69 }
+        }
+      ]
     );
   });
 });

--- a/test/readme.spec.js
+++ b/test/readme.spec.js
@@ -1,13 +1,26 @@
 const expect = require("unexpected");
 const findRelationsInJs = require("../");
 
-it("should have a functional example in the readme", () => {
-  expect(
-    findRelationsInJs(`
-      import foo from './bar.js';
-      require('./baz');
-    `),
-    "to equal",
-    ["./bar.js", "./baz"]
-  );
+const README_EXAMPLE = `
+  import foo from './bar.js';
+  require('./baz');
+`;
+
+describe("README", () => {
+  it("should have a functional example in the readme", () => {
+    expect(findRelationsInJs(README_EXAMPLE), "to equal", [
+      {
+        type: "import",
+        value: "./bar.js",
+        source: "import foo from './bar.js'",
+        offset: { start: 3, end: 29 }
+      },
+      {
+        type: "require",
+        value: "./baz",
+        source: "require('./baz')",
+        offset: { start: 33, end: 49 }
+      }
+    ]);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,19 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@gustavnikolaj/async-main-wrap@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@gustavnikolaj/async-main-wrap/-/async-main-wrap-3.0.1.tgz#b838eb9dfaf9ed81bfc2b47f64d17a83bbcfc71b"
+  integrity sha512-FHh1Tz5Jk5xJphcYpFUMsxCTO+XbgQyCorlbztqBsYRnu5hmuoV/0Q+dJlcOtQCG6cJ5/EHX+VrSsoLBoaTJvQ==
+
+"@gustavnikolaj/find-relations-in-js@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@gustavnikolaj/find-relations-in-js/-/find-relations-in-js-1.2.0.tgz#0f46a2693d19e44429bd07663b1111e7992b79d1"
+  integrity sha512-04upC+0J+i6oDwgfKkA5S3ifrm61ZjEz3DTDOju8SfBnwtwIJzdvjGW2/AWwosLCQjVJ9BLRPacOkXxPXb4MUw==
+  dependencies:
+    acorn "^6.1.1"
+    acorn-jsx "^5.0.1"
+
 acorn-jsx@^5.0.0, acorn-jsx@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
@@ -146,6 +159,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+anymatch@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.0.2.tgz#ddb3a8495d44875423af7b919aace11e91732a41"
+  integrity sha512-rUe9SxpRQlVg4EM8It7JMNWWYHAirTPpbTuvaSKybb5IejNgWB3PGBBX9rrPKDx2pM/p3Wh+7+ASaWRyyAbxmQ==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
 
 append-transform@^1.0.0:
   version "1.0.0"
@@ -215,6 +236,11 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+async-each@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
+  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -242,6 +268,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
+  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -249,6 +280,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+braces@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -293,6 +331,22 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chokidar@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.0.1.tgz#98fe9aa476c55d9aea7841d6325ffdb30e95b40c"
+  integrity sha512-2ww34sJWehnbpV0Q4k4V5Hh7juo7po6z7LUWkcIQnSGN1lHOL8GGtLtfwabKvLFQw/hbSUQ0u6V7OgGYgBzlkQ==
+  dependencies:
+    anymatch "^3.0.1"
+    async-each "^1.0.3"
+    braces "^3.0.2"
+    glob-parent "^5.0.0"
+    is-binary-path "^2.1.0"
+    is-glob "^4.0.1"
+    normalize-path "^3.0.0"
+    readdirp "^3.0.2"
+  optionalDependencies:
+    fsevents "^2.0.6"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -803,6 +857,13 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -874,6 +935,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.0.7.tgz#382c9b443c6cbac4c57187cdda23aa3bf1ccfc2a"
+  integrity sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -920,6 +986,13 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-parent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
+  integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob@7.1.3:
   version "7.1.3"
@@ -1044,6 +1117,16 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+imocha@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/imocha/-/imocha-0.7.0.tgz#fd2606629055c89be1e9522500288463a8f55bee"
+  integrity sha512-R+V3yQ+m9cK5Tfp0S7QxHBGpv3FuLSS7TOQpZqeE8J2K5I0p8jbwK9GvlE6iGslpWpqEk3I7nQQwB3C+T8WEOw==
+  dependencies:
+    "@gustavnikolaj/async-main-wrap" "^3.0.1"
+    "@gustavnikolaj/find-relations-in-js" "^1.2.0"
+    chokidar "^3.0.1"
+    minimatch "3.0.4"
+
 import-fresh@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
@@ -1099,6 +1182,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-binary-path@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
@@ -1145,12 +1235,17 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -1589,6 +1684,11 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -1847,6 +1947,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picomatch@^2.0.4:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
+  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -1971,6 +2076,13 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+readdirp@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.0.2.tgz#cba63348e9e42fc1bd334b1d2ef895b6a043cbd6"
+  integrity sha512-LbyJYv48eywrhOlScq16H/VkCiGKGPC2TpOdZCJ7QXnYEjn3NN/Oblh8QEU3vqfSRBB7OGvh5x45NKiVeNujIQ==
+  dependencies:
+    picomatch "^2.0.4"
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -2316,6 +2428,13 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
 
 tough-cookie@~2.4.3:
   version "2.4.3"


### PR DESCRIPTION
Instead of returning a simple array of strings with extracted paths to the required modules, I've changed the module to return a list of objects describing the require and import statements.

This allows us to also report the error cases and provide enough contextual information for consuming modules to provide better error messages. These two test cases best describe the new possibilities.

```js
  it("should not fail when requiring a variable", () => {
    expect(
      findRelationsInJs(`
        const foo = 'react';
        const bar = require(foo);
      `),
      "to equal",
      [
        {
          error: "Non literal require.",
          type: "require",
          source: "require(foo)",
          offset: { start: 50, end: 62 }
        }
      ]
    );
  });
```

```js
  it("should not crash on an unterminated require statement", () => {
    expect(
      findRelationsInJs(`
        require('fdsf'
      `),
      "to equal",
      [
        {
          error: "Incomplete require statement",
          type: "require",
          source: "require(",
          offset: { start: 9, end: 17 }
        }
      ]
    );
  });
```

@sunesimonsen @alexjeffburke I'd like a sanity check - is this too far? We had most of the information available from the acorn tokenizer already.